### PR TITLE
Refactor the agents directory into composable hooks and rows

### DIFF
--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -28,6 +28,11 @@ export default function Home() {
           name: 'agentget',
           url: 'https://agentget.sh',
           description: 'The AI Agents Package Manager',
+          potentialAction: {
+            '@type': 'SearchAction',
+            target: 'https://agentget.sh/?q={search_term_string}',
+            'query-input': 'required name=search_term_string',
+          },
         }}
       />
       <SiteHeader active="home" />

--- a/website/components/AgentDirectoryRow.tsx
+++ b/website/components/AgentDirectoryRow.tsx
@@ -1,0 +1,221 @@
+'use client';
+
+import Link from 'next/link';
+
+import { getExternalAgentHref, type ExternalAgent } from '@/lib/external-agent';
+import { useCopyToClipboard } from '@/lib/useCopyToClipboard';
+
+function formatStars(count: number): string {
+  return count > 0 ? count.toLocaleString() : '—';
+}
+
+function AgentBadges({ agent }: { agent: ExternalAgent }) {
+  return (
+    <>
+      {agent.hasSkills && (
+        <span className="whitespace-nowrap font-mono text-[11px] text-emerald-400/70">
+          ✓ skills
+        </span>
+      )}
+      {agent.hasInstructions && (
+        <span className="whitespace-nowrap font-mono text-[11px] text-emerald-400/70">
+          ✓ instructions
+        </span>
+      )}
+    </>
+  );
+}
+
+interface AgentDirectoryRowProps {
+  agent: ExternalAgent;
+  index: number;
+  isExpanded: boolean;
+  onToggleExpand: () => void;
+}
+
+export function AgentDirectoryRow({
+  agent,
+  index,
+  isExpanded,
+  onToggleExpand,
+}: AgentDirectoryRowProps) {
+  const { copied, copy } = useCopyToClipboard();
+  const detailsId = `agent-description-${agent.key.replace(/[^a-zA-Z0-9-_]/g, '-')}`;
+
+  return (
+    <div role="listitem" data-testid="agent-row" className="border-b border-white/[0.04]">
+      <div className="px-4 py-3 transition-colors hover:bg-white/[0.02]">
+        <div className="flex items-start gap-3">
+          <span className="w-10 shrink-0 pt-0.5 text-right font-mono text-sm tabular-nums text-neutral-600">
+            {index}
+          </span>
+
+          <div className="w-36 min-w-0 shrink-0 sm:w-48">
+            <Link
+              href={getExternalAgentHref(agent.key)}
+              className="block truncate text-sm font-semibold text-neutral-200 transition-colors hover:text-white"
+            >
+              {agent.name}
+            </Link>
+            <span className="mt-1 block truncate font-mono text-[11px] text-neutral-600 sm:hidden">
+              {agent.repo}
+            </span>
+            <span className="mt-1 block font-mono text-[11px] text-neutral-500 sm:hidden">
+              ☆ {formatStars(agent.numGhStars)}
+            </span>
+          </div>
+
+          <span className="hidden w-40 shrink-0 truncate pt-0.5 font-mono text-xs text-neutral-500 sm:block">
+            {agent.repo}
+          </span>
+
+          <div className="flex-1 min-w-0 pt-0.5">
+            <p className="truncate text-sm text-neutral-500">{agent.shortDescription}</p>
+            <div className="mt-2 flex flex-wrap items-center gap-2 md:hidden">
+              <AgentBadges agent={agent} />
+            </div>
+          </div>
+
+          <a
+            href={`${agent.repoUrl}/stargazers`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hidden w-24 shrink-0 pt-0.5 text-right font-mono text-xs text-neutral-400 transition-colors hover:text-neutral-300 sm:block"
+            aria-label={`View stars for ${agent.repo}`}
+          >
+            {formatStars(agent.numGhStars)}
+          </a>
+
+          <div className="shrink-0 sm:w-44">
+            <div className="flex flex-wrap justify-end gap-2">
+              <button
+                type="button"
+                onClick={() => copy(agent.installCommand)}
+                className="inline-flex cursor-pointer items-center gap-1.5 rounded-md bg-neutral-900 px-3 py-1.5 font-mono text-xs text-neutral-300 ring-1 ring-white/[0.06] transition-colors hover:bg-neutral-800"
+                aria-label={
+                  copied
+                    ? `Copied: ${agent.installCommand}`
+                    : `Copy install command for ${agent.name}`
+                }
+              >
+                {copied ? (
+                  <>
+                    <svg
+                      className="h-3.5 w-3.5 text-emerald-400"
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                      strokeWidth="2"
+                    >
+                      <polyline
+                        points="20 6 9 17 4 12"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      />
+                    </svg>
+                    Copied
+                  </>
+                ) : (
+                  <>
+                    <svg
+                      className="h-3.5 w-3.5"
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                      strokeWidth="2"
+                    >
+                      <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+                      <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+                    </svg>
+                    Copy
+                  </>
+                )}
+              </button>
+
+              <button
+                type="button"
+                onClick={onToggleExpand}
+                className="inline-flex cursor-pointer items-center gap-1.5 rounded-md bg-neutral-900 px-3 py-1.5 font-mono text-xs text-neutral-300 ring-1 ring-white/[0.06] transition-colors hover:bg-neutral-800"
+                aria-expanded={isExpanded}
+                aria-controls={detailsId}
+                aria-label={
+                  isExpanded ? `Show less about ${agent.name}` : `Show more about ${agent.name}`
+                }
+              >
+                <svg
+                  className={`h-3.5 w-3.5 transition-transform ${isExpanded ? 'rotate-90' : ''}`}
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                  strokeWidth="2"
+                >
+                  <polyline points="9 18 15 12 9 6" strokeLinecap="round" strokeLinejoin="round" />
+                </svg>
+                {isExpanded ? 'Less' : 'More'}
+              </button>
+            </div>
+
+            <div className="mt-2 hidden flex-wrap items-center justify-end gap-2.5 md:flex">
+              <AgentBadges agent={agent} />
+            </div>
+          </div>
+        </div>
+
+        {isExpanded && (
+          <div
+            id={detailsId}
+            className="mt-3 ml-[3.25rem] rounded-lg border border-white/[0.06] bg-neutral-950/60 px-4 py-3 sm:ml-0 sm:pl-14"
+          >
+            <div className="mb-2 flex flex-wrap items-center gap-3 text-[11px] font-medium uppercase tracking-wider text-neutral-600">
+              <span>Full description</span>
+              <span className="font-mono normal-case text-neutral-500">
+                ☆ {formatStars(agent.numGhStars)} stars
+              </span>
+            </div>
+
+            <p className="break-words whitespace-pre-wrap text-sm leading-6 text-neutral-300">
+              {agent.shortDescription}
+            </p>
+
+            <div className="mt-3 rounded-md border border-white/[0.05] bg-black/20 px-3 py-2">
+              <code className="block break-all font-mono text-xs text-neutral-400">
+                <span className="text-neutral-600">$ </span>
+                {agent.installCommand}
+              </code>
+            </div>
+
+            <div className="mt-3 flex flex-wrap items-center gap-3 font-mono text-xs">
+              <Link
+                href={getExternalAgentHref(agent.key)}
+                className="text-neutral-400 transition-colors hover:text-white"
+              >
+                Open details →
+              </Link>
+              <a
+                href={agent.repoUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-neutral-400 transition-colors hover:text-white"
+              >
+                Open repository ↗
+              </a>
+              {agent.hasValidSourceUrl && agent.sourceUrl && agent.sourceKind !== 'repo' && (
+                <a
+                  href={agent.sourceUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-neutral-400 transition-colors hover:text-white"
+                >
+                  View source ↗
+                </a>
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+      <span className="sr-only" role="status" aria-live="polite">
+        {copied ? 'Copied' : ''}
+      </span>
+    </div>
+  );
+}

--- a/website/components/AgentsDirectory.tsx
+++ b/website/components/AgentsDirectory.tsx
@@ -1,117 +1,34 @@
 'use client';
 
-import Link from 'next/link';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 
-interface Agent {
-  key: string;
-  name: string;
-  repo: string;
-  owner: string;
-  shortDescription: string;
-  hasSkills: boolean;
-  hasInstructions: boolean;
-  installCommand: string;
-  url: string;
-  numGhStars: number;
-  repoUrl: string;
-  sourceUrl?: string;
-  sourceKind: string;
-  hasValidSourceUrl: boolean;
-}
+import { AgentDirectoryRow } from '@/components/AgentDirectoryRow';
+import type { ExternalAgent } from '@/lib/external-agent';
+import { useAgentsCatalog } from '@/lib/useAgentsCatalog';
+import { useDirectoryQuery } from '@/lib/useDirectoryQuery';
+import { useDirectoryResults } from '@/lib/useDirectoryResults';
+import { useFocusOnSlash } from '@/lib/useFocusOnSlash';
 
-const PAGE_SIZE = 50;
+export function AgentsDirectory({ initialAgents }: { initialAgents: ExternalAgent[] }) {
+  const { agents, status, retry } = useAgentsCatalog(initialAgents);
+  const { search, query, page, setPage, updateSearch } = useDirectoryQuery(status);
+  const { rows, filtered, totalPages, currentPage, isSearchPending, PAGE_SIZE } =
+    useDirectoryResults({ agents, query, status, page });
 
-function formatStars(count: number): string {
-  return count > 0 ? count.toLocaleString() : '—';
-}
-
-function getExternalAgentHref(key: string) {
-  return `/agents/${key}`;
-}
-
-export function AgentsDirectory({ initialAgents }: { initialAgents: Agent[] }) {
-  const [allAgents, setAllAgents] = useState<Agent[] | null>(null);
-  const [search, setSearch] = useState('');
-  const [page, setPage] = useState(1);
-  const [copiedKey, setCopiedKey] = useState<string | null>(null);
-  const [expandedKey, setExpandedKey] = useState<string | null>(null);
   const searchRef = useRef<HTMLInputElement>(null);
+  useFocusOnSlash(searchRef);
 
-  // Lazy load all agents on the client
-  useEffect(() => {
-    fetch('/agents-index.json')
-      .then((res) => res.json())
-      .then((data) => setAllAgents(data as Agent[]))
-      .catch(() => void 0);
-  }, []);
+  const [expandedKey, setExpandedKey] = useState<string | null>(null);
 
-  const agents = allAgents ?? initialAgents;
-
-  const sorted = useMemo(
-    () => [...agents].sort((a, b) => b.numGhStars - a.numGhStars || a.name.localeCompare(b.name)),
-    [agents]
-  );
-
-  const filtered = useMemo(() => {
-    if (!search.trim()) return sorted;
-    const q = search.toLowerCase();
-
-    return sorted.filter(
-      (agent) =>
-        agent.name.toLowerCase().includes(q) ||
-        agent.repo.toLowerCase().includes(q) ||
-        agent.shortDescription.toLowerCase().includes(q)
-    );
-  }, [search, sorted]);
-
-  const totalPages = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE));
-  const rows = filtered.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
-
-  useEffect(() => {
-    setPage(1);
+  const handleSearchChange = (next: string) => {
+    updateSearch(next);
     setExpandedKey(null);
-  }, [search]);
-
-  useEffect(() => {
-    const handler = (event: KeyboardEvent) => {
-      if (
-        event.key === '/' &&
-        !['INPUT', 'TEXTAREA', 'SELECT'].includes((event.target as HTMLElement).tagName)
-      ) {
-        event.preventDefault();
-        searchRef.current?.focus();
-      }
-    };
-
-    window.addEventListener('keydown', handler);
-    return () => window.removeEventListener('keydown', handler);
-  }, []);
-
-  const copyInstall = async (command: string, key: string) => {
-    try {
-      await navigator.clipboard.writeText(command);
-      setCopiedKey(key);
-      setTimeout(() => setCopiedKey(null), 2000);
-    } catch {
-      void 0;
-    }
   };
 
-  const renderBadges = (agent: Agent) => (
-    <>
-      {agent.hasSkills && (
-        <span className="whitespace-nowrap font-mono text-[11px] text-emerald-400/70">
-          ✓ skills
-        </span>
-      )}
-      {agent.hasInstructions && (
-        <span className="whitespace-nowrap font-mono text-[11px] text-emerald-400/70">
-          ✓ instructions
-        </span>
-      )}
-    </>
-  );
+  const countLabel =
+    status === 'ready'
+      ? agents.length.toLocaleString()
+      : `${initialAgents.length.toLocaleString()}+`;
 
   return (
     <section
@@ -121,9 +38,15 @@ export function AgentsDirectory({ initialAgents }: { initialAgents: Agent[] }) {
       <div className="mb-8 flex items-baseline gap-3">
         <h2 className="text-2xl font-bold tracking-tight sm:text-3xl">Agents Directory</h2>
         <span className="inline-flex items-center rounded-full bg-emerald-500/10 px-2.5 py-1 font-mono text-xs font-medium text-emerald-400 ring-1 ring-emerald-500/20">
-          {allAgents ? allAgents.length.toLocaleString() : '...'}
+          {countLabel}
         </span>
       </div>
+
+      <span className="sr-only" role="status" aria-live="polite">
+        {status === 'loading' && 'Loading full catalog'}
+        {status === 'error' && 'Failed to load full catalog'}
+        {status === 'ready' && `${agents.length.toLocaleString()} agents`}
+      </span>
 
       <div className="relative mb-6">
         <svg
@@ -132,18 +55,25 @@ export function AgentsDirectory({ initialAgents }: { initialAgents: Agent[] }) {
           stroke="currentColor"
           viewBox="0 0 24 24"
           strokeWidth="2"
+          aria-hidden="true"
         >
           <circle cx="11" cy="11" r="8" />
           <path d="m21 21-4.3-4.3" strokeLinecap="round" />
         </svg>
 
+        <label htmlFor="agents-search" className="sr-only">
+          Search agents
+        </label>
         <input
           ref={searchRef}
-          type="text"
+          id="agents-search"
+          type="search"
           placeholder="Search agents..."
+          autoComplete="off"
           value={search}
-          onChange={(event) => setSearch(event.target.value)}
+          onChange={(event) => handleSearchChange(event.target.value)}
           data-testid="agents-search"
+          aria-controls="agents-table-body"
           className="w-full rounded-lg border border-white/[0.08] bg-neutral-900/60 py-3 pl-10 pr-14 text-sm text-neutral-200 placeholder:text-neutral-600 transition-all focus:border-emerald-400/30 focus:outline-none focus:ring-2 focus:ring-emerald-400"
         />
 
@@ -151,6 +81,19 @@ export function AgentsDirectory({ initialAgents }: { initialAgents: Agent[] }) {
           /
         </kbd>
       </div>
+
+      {status === 'error' && (
+        <p className="mb-6 text-sm text-neutral-500">
+          Couldn&apos;t load the full catalog.{' '}
+          <button
+            type="button"
+            onClick={retry}
+            className="font-mono text-neutral-300 underline-offset-2 hover:text-white hover:underline"
+          >
+            Retry
+          </button>
+        </p>
+      )}
 
       <div className="flex items-center gap-3 border-b border-white/[0.08] px-4 py-2.5 text-[11px] font-medium uppercase tracking-wider text-neutral-600 select-none">
         <span className="w-10 shrink-0 text-right">#</span>
@@ -161,204 +104,47 @@ export function AgentsDirectory({ initialAgents }: { initialAgents: Agent[] }) {
         <span className="hidden w-44 shrink-0 text-right sm:block">Actions</span>
       </div>
 
-      <div data-testid="agents-table-body" role="list">
-        {rows.map((agent, index) => {
-          const globalIdx = (page - 1) * PAGE_SIZE + index;
-          const isCopied = copiedKey === agent.key;
-          const isExpanded = expandedKey === agent.key;
-          const detailsId = `agent-description-${agent.key.replace(/[^a-zA-Z0-9-_]/g, '-')}`;
-
-          return (
-            <div
+      <div
+        id="agents-table-body"
+        data-testid="agents-table-body"
+        role="list"
+        aria-busy={isSearchPending || undefined}
+      >
+        {isSearchPending ? (
+          <div className="py-20 text-center text-sm text-neutral-600" role="status">
+            Loading catalog…
+          </div>
+        ) : status === 'error' && query !== '' ? (
+          <div className="py-20 text-center text-sm text-neutral-600">
+            Search needs the full catalog.
+          </div>
+        ) : (
+          rows.map((agent, index) => (
+            <AgentDirectoryRow
               key={agent.key}
-              role="listitem"
-              data-testid="agent-row"
-              className="border-b border-white/[0.04]"
-            >
-              <div className="px-4 py-3 transition-colors hover:bg-white/[0.02]">
-                <div className="flex items-start gap-3">
-                  <span className="w-10 shrink-0 pt-0.5 text-right font-mono text-sm tabular-nums text-neutral-600">
-                    {globalIdx + 1}
-                  </span>
-
-                  <div className="w-36 min-w-0 shrink-0 sm:w-48">
-                    <Link
-                      href={getExternalAgentHref(agent.key)}
-                      className="block truncate text-sm font-semibold text-neutral-200 transition-colors hover:text-white"
-                    >
-                      {agent.name}
-                    </Link>
-                    <span className="mt-1 block truncate font-mono text-[11px] text-neutral-600 sm:hidden">
-                      {agent.repo}
-                    </span>
-                    <span className="mt-1 block font-mono text-[11px] text-neutral-500 sm:hidden">
-                      ☆ {formatStars(agent.numGhStars)}
-                    </span>
-                  </div>
-
-                  <span className="hidden w-40 shrink-0 truncate pt-0.5 font-mono text-xs text-neutral-500 sm:block">
-                    {agent.repo}
-                  </span>
-
-                  <div className="flex-1 min-w-0 pt-0.5">
-                    <p className="truncate text-sm text-neutral-500">{agent.shortDescription}</p>
-                    <div className="mt-2 flex flex-wrap items-center gap-2 md:hidden">
-                      {renderBadges(agent)}
-                    </div>
-                  </div>
-
-                  <a
-                    href={`${agent.repoUrl}/stargazers`}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="hidden w-24 shrink-0 pt-0.5 text-right font-mono text-xs text-neutral-400 transition-colors hover:text-neutral-300 sm:block"
-                    aria-label={`View stars for ${agent.repo}`}
-                  >
-                    {formatStars(agent.numGhStars)}
-                  </a>
-
-                  <div className="shrink-0 sm:w-44">
-                    <div className="flex flex-wrap justify-end gap-2">
-                      <button
-                        onClick={() => copyInstall(agent.installCommand, agent.key)}
-                        className="inline-flex cursor-pointer items-center gap-1.5 rounded-md bg-neutral-900 px-3 py-1.5 font-mono text-xs text-neutral-300 ring-1 ring-white/[0.06] transition-colors hover:bg-neutral-800"
-                        aria-label={`Copy install command for ${agent.name}`}
-                      >
-                        {isCopied ? (
-                          <>
-                            <svg
-                              className="h-3.5 w-3.5 text-emerald-400"
-                              fill="none"
-                              stroke="currentColor"
-                              viewBox="0 0 24 24"
-                              strokeWidth="2"
-                            >
-                              <polyline
-                                points="20 6 9 17 4 12"
-                                strokeLinecap="round"
-                                strokeLinejoin="round"
-                              />
-                            </svg>
-                            Copied
-                          </>
-                        ) : (
-                          <>
-                            <svg
-                              className="h-3.5 w-3.5"
-                              fill="none"
-                              stroke="currentColor"
-                              viewBox="0 0 24 24"
-                              strokeWidth="2"
-                            >
-                              <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
-                              <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
-                            </svg>
-                            Copy
-                          </>
-                        )}
-                      </button>
-
-                      <button
-                        onClick={() =>
-                          setExpandedKey((current) => (current === agent.key ? null : agent.key))
-                        }
-                        className="inline-flex cursor-pointer items-center gap-1.5 rounded-md bg-neutral-900 px-3 py-1.5 font-mono text-xs text-neutral-300 ring-1 ring-white/[0.06] transition-colors hover:bg-neutral-800"
-                        aria-expanded={isExpanded}
-                        aria-controls={detailsId}
-                      >
-                        <svg
-                          className={`h-3.5 w-3.5 transition-transform ${isExpanded ? 'rotate-90' : ''}`}
-                          fill="none"
-                          stroke="currentColor"
-                          viewBox="0 0 24 24"
-                          strokeWidth="2"
-                        >
-                          <polyline
-                            points="9 18 15 12 9 6"
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                          />
-                        </svg>
-                        {isExpanded ? 'Less' : 'More'}
-                      </button>
-                    </div>
-
-                    <div className="mt-2 hidden flex-wrap items-center justify-end gap-2.5 md:flex">
-                      {renderBadges(agent)}
-                    </div>
-                  </div>
-                </div>
-
-                {isExpanded && (
-                  <div
-                    id={detailsId}
-                    className="mt-3 ml-[3.25rem] rounded-lg border border-white/[0.06] bg-neutral-950/60 px-4 py-3 sm:ml-0 sm:pl-14"
-                  >
-                    <div className="mb-2 flex flex-wrap items-center gap-3 text-[11px] font-medium uppercase tracking-wider text-neutral-600">
-                      <span>Full description</span>
-                      <span className="font-mono normal-case text-neutral-500">
-                        ☆ {formatStars(agent.numGhStars)} stars
-                      </span>
-                    </div>
-
-                    <p className="break-words whitespace-pre-wrap text-sm leading-6 text-neutral-300">
-                      {agent.shortDescription}
-                    </p>
-
-                    <div className="mt-3 rounded-md border border-white/[0.05] bg-black/20 px-3 py-2">
-                      <code className="block break-all font-mono text-xs text-neutral-400">
-                        <span className="text-neutral-600">$ </span>
-                        {agent.installCommand}
-                      </code>
-                    </div>
-
-                    <div className="mt-3 flex flex-wrap items-center gap-3 font-mono text-xs">
-                      <Link
-                        href={getExternalAgentHref(agent.key)}
-                        className="text-neutral-400 transition-colors hover:text-white"
-                      >
-                        Open details →
-                      </Link>
-                      <a
-                        href={agent.repoUrl}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-neutral-400 transition-colors hover:text-white"
-                      >
-                        Open repository ↗
-                      </a>
-                      {agent.hasValidSourceUrl &&
-                        agent.sourceUrl &&
-                        agent.sourceKind !== 'repo' && (
-                          <a
-                            href={agent.sourceUrl}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="text-neutral-400 transition-colors hover:text-white"
-                          >
-                            View source ↗
-                          </a>
-                        )}
-                    </div>
-                  </div>
-                )}
-              </div>
-            </div>
-          );
-        })}
+              agent={agent}
+              index={(currentPage - 1) * PAGE_SIZE + index + 1}
+              isExpanded={expandedKey === agent.key}
+              onToggleExpand={() =>
+                setExpandedKey((current) => (current === agent.key ? null : agent.key))
+              }
+            />
+          ))
+        )}
       </div>
 
-      {filtered.length === 0 && (
+      {status === 'ready' && query !== '' && filtered.length === 0 && (
         <div className="py-20 text-center text-sm text-neutral-600">
           No agents found for &ldquo;{search}&rdquo;
         </div>
       )}
 
-      {totalPages > 1 && (
+      {!isSearchPending && totalPages > 1 && (
         <div className="mt-6 flex items-center justify-between pt-5" data-testid="pagination">
           <button
-            onClick={() => setPage((current) => Math.max(1, current - 1))}
-            disabled={page === 1}
+            type="button"
+            onClick={() => setPage(Math.max(1, currentPage - 1))}
+            disabled={currentPage === 1}
             data-testid="prev-page"
             className="rounded-md px-3 py-1.5 font-mono text-sm text-neutral-400 transition-colors hover:bg-white/[0.04] hover:text-white disabled:cursor-not-allowed disabled:text-neutral-700 disabled:hover:bg-transparent"
           >
@@ -369,12 +155,13 @@ export function AgentsDirectory({ initialAgents }: { initialAgents: Agent[] }) {
             className="font-mono text-sm tabular-nums text-neutral-600"
             data-testid="page-indicator"
           >
-            Page {page} of {totalPages}
+            Page {currentPage} of {totalPages}
           </span>
 
           <button
-            onClick={() => setPage((current) => Math.min(totalPages, current + 1))}
-            disabled={page === totalPages}
+            type="button"
+            onClick={() => setPage(Math.min(totalPages, currentPage + 1))}
+            disabled={currentPage === totalPages}
             data-testid="next-page"
             className="rounded-md px-3 py-1.5 font-mono text-sm text-neutral-400 transition-colors hover:bg-white/[0.04] hover:text-white disabled:cursor-not-allowed disabled:text-neutral-700 disabled:hover:bg-transparent"
           >
@@ -383,7 +170,7 @@ export function AgentsDirectory({ initialAgents }: { initialAgents: Agent[] }) {
         </div>
       )}
 
-      {search.trim() && filtered.length > 0 && (
+      {status === 'ready' && query !== '' && filtered.length > 0 && (
         <p className="mt-3 text-center font-mono text-xs text-neutral-600">
           {filtered.length.toLocaleString()} result
           {filtered.length !== 1 ? 's' : ''} for &ldquo;{search}&rdquo;

--- a/website/lib/external-agent.ts
+++ b/website/lib/external-agent.ts
@@ -1,0 +1,22 @@
+export interface ExternalAgent {
+  key: string;
+  name: string;
+  repo: string;
+  owner: string;
+  shortDescription: string;
+  hasSkills: boolean;
+  hasInstructions: boolean;
+  installCommand: string;
+  url: string;
+  numGhStars: number;
+  repoUrl: string;
+  sourceUrl?: string;
+  sourceKind: string;
+  sourcePath?: string;
+  sourceRef?: string;
+  hasValidSourceUrl: boolean;
+}
+
+export function getExternalAgentHref(key: string) {
+  return `/agents/${key}`;
+}

--- a/website/lib/external-agents-catalog.ts
+++ b/website/lib/external-agents-catalog.ts
@@ -2,7 +2,7 @@ import 'server-only';
 
 import agentsData from '@/public/agents-index.json';
 
-import type { ExternalAgent } from '@/lib/external-agents';
+import type { ExternalAgent } from '@/lib/external-agent';
 
 const EXTERNAL_AGENTS = agentsData as ExternalAgent[];
 

--- a/website/lib/external-agents.ts
+++ b/website/lib/external-agents.ts
@@ -2,31 +2,13 @@ import 'server-only';
 
 import topAgentsData from '@/public/agents-top.json';
 
-export interface ExternalAgent {
-  key: string;
-  name: string;
-  repo: string;
-  owner: string;
-  shortDescription: string;
-  hasSkills: boolean;
-  hasInstructions: boolean;
-  installCommand: string;
-  url: string;
-  numGhStars: number;
-  repoUrl: string;
-  sourceUrl?: string;
-  sourceKind: string;
-  sourcePath?: string;
-  sourceRef?: string;
-  hasValidSourceUrl: boolean;
-}
+import type { ExternalAgent } from '@/lib/external-agent';
+
+export type { ExternalAgent } from '@/lib/external-agent';
+export { getExternalAgentHref } from '@/lib/external-agent';
 
 const TOP_EXTERNAL_AGENTS = topAgentsData as ExternalAgent[];
 
 export function getTopExternalAgents(limit = 50) {
   return TOP_EXTERNAL_AGENTS.slice(0, limit);
-}
-
-export function getExternalAgentHref(key: string) {
-  return `/agents/${key}`;
 }

--- a/website/lib/useAgentsCatalog.ts
+++ b/website/lib/useAgentsCatalog.ts
@@ -1,0 +1,46 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import type { ExternalAgent } from '@/lib/external-agent';
+
+export type AgentsCatalogStatus = 'loading' | 'ready' | 'error';
+
+export function useAgentsCatalog(initialAgents: ExternalAgent[]) {
+  const initialAgentsRef = useRef(initialAgents);
+  initialAgentsRef.current = initialAgents;
+
+  const [agents, setAgents] = useState(initialAgents);
+  const [status, setStatus] = useState<AgentsCatalogStatus>('loading');
+  const [retryCount, setRetryCount] = useState(0);
+
+  const retry = useCallback(() => {
+    setStatus('loading');
+    setRetryCount((count) => count + 1);
+  }, []);
+
+  useEffect(() => {
+    const controller = new AbortController();
+
+    fetch('/agents-index.json', { signal: controller.signal })
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error(`Failed to load catalog (${response.status})`);
+        }
+        return response.json() as Promise<ExternalAgent[]>;
+      })
+      .then((data) => {
+        setAgents(data);
+        setStatus('ready');
+      })
+      .catch((error: unknown) => {
+        if (error instanceof DOMException && error.name === 'AbortError') return;
+        setAgents(initialAgentsRef.current);
+        setStatus('error');
+      });
+
+    return () => controller.abort();
+  }, [retryCount]);
+
+  return { agents, status, retry };
+}

--- a/website/lib/useDirectoryQuery.ts
+++ b/website/lib/useDirectoryQuery.ts
@@ -1,0 +1,64 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+import type { AgentsCatalogStatus } from '@/lib/useAgentsCatalog';
+
+const URL_SYNC_MS = 300;
+
+function readDirectoryParams() {
+  const params = new URLSearchParams(window.location.search);
+  const q = params.get('q') ?? '';
+  const page = Math.max(1, Number(params.get('page')) || 1);
+  return { q, page };
+}
+
+function writeDirectoryParams(search: string, page: number) {
+  const url = new URL(window.location.href);
+  const q = search.trim();
+
+  if (q) url.searchParams.set('q', q);
+  else url.searchParams.delete('q');
+
+  if (page > 1) url.searchParams.set('page', String(page));
+  else url.searchParams.delete('page');
+
+  const next = `${url.pathname}${url.search}${url.hash}`;
+  const current = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+  if (next !== current) {
+    window.history.replaceState(null, '', next);
+  }
+}
+
+export function useDirectoryQuery(catalogStatus: AgentsCatalogStatus) {
+  const [search, setSearch] = useState('');
+  const [page, setPage] = useState(1);
+  const [urlReady, setUrlReady] = useState(false);
+
+  useEffect(() => {
+    const { q, page: urlPage } = readDirectoryParams();
+    setSearch(q);
+    setPage(urlPage);
+    setUrlReady(true);
+  }, []);
+
+  useEffect(() => {
+    if (!urlReady) return;
+    if (search.trim() !== '' && catalogStatus !== 'ready') return;
+
+    const timeout = window.setTimeout(() => {
+      writeDirectoryParams(search, page);
+    }, URL_SYNC_MS);
+
+    return () => window.clearTimeout(timeout);
+  }, [search, page, urlReady, catalogStatus]);
+
+  const updateSearch = useCallback((next: string) => {
+    setSearch(next);
+    setPage(1);
+  }, []);
+
+  const query = search.trim();
+
+  return { search, query, page, setPage, updateSearch };
+}

--- a/website/lib/useDirectoryResults.ts
+++ b/website/lib/useDirectoryResults.ts
@@ -1,0 +1,52 @@
+'use client';
+
+import { useMemo } from 'react';
+
+import type { ExternalAgent } from '@/lib/external-agent';
+import type { AgentsCatalogStatus } from '@/lib/useAgentsCatalog';
+
+const PAGE_SIZE = 50;
+
+interface UseDirectoryResultsInput {
+  agents: ExternalAgent[];
+  query: string;
+  status: AgentsCatalogStatus;
+  page: number;
+}
+
+export function useDirectoryResults({ agents, query, status, page }: UseDirectoryResultsInput) {
+  const isSearchPending = query !== '' && status === 'loading';
+  const isSearchBlocked = query !== '' && status !== 'ready';
+
+  const sorted = useMemo(
+    () => [...agents].sort((a, b) => b.numGhStars - a.numGhStars || a.name.localeCompare(b.name)),
+    [agents]
+  );
+
+  const filtered = useMemo(() => {
+    if (isSearchBlocked) return [];
+    if (!query) return sorted;
+    const q = query.toLowerCase();
+
+    return sorted.filter(
+      (agent) =>
+        agent.name.toLowerCase().includes(q) ||
+        agent.repo.toLowerCase().includes(q) ||
+        agent.shortDescription.toLowerCase().includes(q)
+    );
+  }, [isSearchBlocked, query, sorted]);
+
+  const totalPages = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE));
+  const currentPage = Math.min(page, totalPages);
+  const rows = filtered.slice((currentPage - 1) * PAGE_SIZE, currentPage * PAGE_SIZE);
+
+  return {
+    rows,
+    filtered,
+    totalPages,
+    currentPage,
+    isSearchPending,
+    isSearchBlocked,
+    PAGE_SIZE,
+  };
+}

--- a/website/lib/useFocusOnSlash.ts
+++ b/website/lib/useFocusOnSlash.ts
@@ -1,0 +1,23 @@
+'use client';
+
+import { useEffect, type RefObject } from 'react';
+
+export function useFocusOnSlash(ref: RefObject<HTMLElement | null>) {
+  useEffect(() => {
+    const handler = (event: KeyboardEvent) => {
+      if (event.key !== '/') return;
+      if (event.metaKey || event.ctrlKey || event.altKey) return;
+
+      const target = event.target as HTMLElement | null;
+      if (!target) return;
+      if (['INPUT', 'TEXTAREA', 'SELECT'].includes(target.tagName)) return;
+      if (target.isContentEditable) return;
+
+      event.preventDefault();
+      ref.current?.focus();
+    };
+
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [ref]);
+}


### PR DESCRIPTION
## Summary
- Split the 400-line `AgentsDirectory` god component into composable hooks (`useAgentsCatalog`, `useDirectoryQuery`, `useDirectoryResults`, `useFocusOnSlash`) and a per-row component (`AgentDirectoryRow`).
- Add client-safe `ExternalAgent` type in `lib/external-agent.ts` so the directory no longer duplicates types or reimplements `getExternalAgentHref`.
- Fetch the full catalog with abort, `res.ok`, error/retry, and honest loading states — no more silent failure stuck on 50 agents.
- Make search URL-addressable via client-only `?q=` and `page` sync (`replaceState`), without dynamizing the homepage. Restore `SearchAction` JSON-LD now that `/?q=` is real.
- Row copy uses `useCopyToClipboard` with live region; expand accordion stays in the parent.

## Test plan
- [ ] Homepage loads top 50 agents SSR; badge shows `50+` then full count when catalog loads.
- [ ] Search filters agents by name, repo, description; URL updates to `/?q=...` after debounce.
- [ ] Shared link `/?q=cursor` loads with search pre-filled and correct results.
- [ ] Pagination updates `?page=`; Previous/Next work; page resets to 1 on new search.
- [ ] `/` focuses search when not in an input; ignores Cmd+/ and Ctrl+/.
- [ ] Row Copy button copies install command and announces "Copied" to screen readers.
- [ ] Catalog fetch failure shows Retry; search while loading shows "Loading catalog…" not fake empty state.
- [ ] Expand/collapse row details works; only one row expanded at a time.


Made with [Cursor](https://cursor.com)