### PR TITLE
Move header and footer into root layout, add skip link

### DIFF
--- a/website/app/agents/[...slug]/page.tsx
+++ b/website/app/agents/[...slug]/page.tsx
@@ -3,7 +3,6 @@ import Link from 'next/link';
 import { notFound } from 'next/navigation';
 
 import { JsonLd } from '@/components/JsonLd';
-import { SiteHeader } from '@/components/SiteHeader';
 import { getExternalAgent, getExternalAgents } from '@/lib/external-agents-catalog';
 import { getExternalAgentHref } from '@/lib/external-agents';
 
@@ -79,9 +78,7 @@ export default async function ExternalAgentPage({ params }: ExternalAgentPagePro
           },
         }}
       />
-      <SiteHeader currentPath={`/agents/${slug.join('/')}`} />
-
-      <main className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-16 sm:py-20">
+      <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-16 sm:py-20">
         <div className="text-sm text-neutral-500">
           <Link href="/" className="hover:text-white transition-colors">
             Home
@@ -197,7 +194,7 @@ export default async function ExternalAgentPage({ params }: ExternalAgentPagePro
             )}
           </aside>
         </section>
-      </main>
+      </div>
     </>
   );
 }

--- a/website/app/audits/page.tsx
+++ b/website/app/audits/page.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from 'next';
 import { AgentAudits } from '@/components/AgentAudits';
-import { SiteHeader } from '@/components/SiteHeader';
 
 export const metadata: Metadata = {
   title: 'AI Agent Capability Audits',
@@ -12,7 +11,6 @@ export const metadata: Metadata = {
 export default function AuditsPage() {
   return (
     <>
-      <SiteHeader currentPath="/audits" />
       <AgentAudits />
     </>
   );

--- a/website/app/docs/agents/[slug]/page.tsx
+++ b/website/app/docs/agents/[slug]/page.tsx
@@ -3,7 +3,6 @@ import Link from 'next/link';
 import { notFound } from 'next/navigation';
 
 import { DocsNav } from '@/components/DocsNav';
-import { SiteHeader } from '@/components/SiteHeader';
 import { getBuiltinAgentDoc, getBuiltinAgentDocs } from '@/lib/builtin-agent-docs';
 import { getBuiltinAgentInstallCommand } from '@/lib/builtin-agents';
 
@@ -55,9 +54,7 @@ export default async function AgentDocPage({ params }: AgentDocPageProps) {
 
   return (
     <>
-      <SiteHeader currentPath={`/docs/agents/${slug}`} />
-
-      <main className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-16 sm:py-20">
+      <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-16 sm:py-20">
         <DocsNav active="agents" />
 
         <div className="text-sm text-neutral-500">
@@ -134,7 +131,7 @@ export default async function AgentDocPage({ params }: AgentDocPageProps) {
             </div>
           </aside>
         </section>
-      </main>
+      </div>
     </>
   );
 }

--- a/website/app/docs/agents/page.tsx
+++ b/website/app/docs/agents/page.tsx
@@ -2,7 +2,6 @@ import type { Metadata } from 'next';
 import Link from 'next/link';
 
 import { DocsNav } from '@/components/DocsNav';
-import { SiteHeader } from '@/components/SiteHeader';
 import { BUILTIN_AGENTS, getBuiltinAgentInstallCommand } from '@/lib/builtin-agents';
 
 export const metadata: Metadata = {
@@ -15,9 +14,7 @@ export const metadata: Metadata = {
 export default function AgentsDocsPage() {
   return (
     <>
-      <SiteHeader currentPath="/docs/agents" />
-
-      <main className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-16 sm:py-20">
+      <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-16 sm:py-20">
         <DocsNav active="agents" />
 
         <section className="max-w-3xl">
@@ -60,7 +57,7 @@ export default function AgentsDocsPage() {
             </article>
           ))}
         </section>
-      </main>
+      </div>
     </>
   );
 }

--- a/website/app/docs/page.tsx
+++ b/website/app/docs/page.tsx
@@ -2,7 +2,6 @@ import type { Metadata } from 'next';
 import Link from 'next/link';
 
 import { DocsNav } from '@/components/DocsNav';
-import { SiteHeader } from '@/components/SiteHeader';
 import { SubmitAgentSection } from '@/components/SubmitAgentSection';
 import { BUILTIN_AGENTS, getBuiltinAgentInstallCommand } from '@/lib/builtin-agents';
 
@@ -18,9 +17,7 @@ const featuredAgents = BUILTIN_AGENTS.slice(0, 3);
 export default function DocsPage() {
   return (
     <>
-      <SiteHeader currentPath="/docs" />
-
-      <main className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-16 sm:py-20">
+      <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-16 sm:py-20">
         <DocsNav active="overview" />
 
         <section className="max-w-3xl">
@@ -96,7 +93,7 @@ export default function DocsPage() {
         <div className="mt-16 -mx-4 sm:-mx-6 lg:-mx-8 border-t border-white/[0.06]">
           <SubmitAgentSection />
         </div>
-      </main>
+      </div>
     </>
   );
 }

--- a/website/app/layout.tsx
+++ b/website/app/layout.tsx
@@ -2,6 +2,9 @@ import type { Metadata } from 'next';
 import { Geist, Geist_Mono } from 'next/font/google';
 import './globals.css';
 
+import { SiteFooter } from '@/components/SiteFooter';
+import { SiteHeader } from '@/components/SiteHeader';
+
 const geistSans = Geist({
   variable: '--font-geist-sans',
   subsets: ['latin'],
@@ -55,7 +58,17 @@ export default function RootLayout({
   return (
     <html lang="en" className="dark">
       <body className={`${geistSans.variable} ${geistMono.variable} font-sans antialiased`}>
-        {children}
+        <a
+          href="#main"
+          className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-100 focus:rounded focus:bg-neutral-900 focus:px-4 focus:py-2 focus:text-sm focus:text-white"
+        >
+          Skip to content
+        </a>
+        <SiteHeader />
+        <main id="main" tabIndex={-1} className="outline-none">
+          {children}
+        </main>
+        <SiteFooter />
       </body>
     </html>
   );

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -5,7 +5,6 @@ import { BuiltinAgents } from '@/components/BuiltinAgents';
 import { CopyableCommand } from '@/components/CopyableCommand';
 import { DocsSection } from '@/components/DocsSection';
 import { JsonLd } from '@/components/JsonLd';
-import { SiteHeader } from '@/components/SiteHeader';
 import { SubmitAgentSection } from '@/components/SubmitAgentSection';
 import { SupportedTargetsMarquee } from '@/components/SupportedTargetsMarquee';
 import { getTopExternalAgents } from '@/lib/external-agents';
@@ -35,48 +34,45 @@ export default function Home() {
           },
         }}
       />
-      <SiteHeader active="home" />
 
-      <main>
-        <section className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 pt-16 sm:pt-20 pb-20 sm:pb-28">
-          <div className="grid grid-cols-1 lg:grid-cols-[auto_1fr] gap-10 lg:gap-14 items-start">
-            <div className="w-[56ch] max-w-full">
-              <BrandMark />
-              <SupportedTargetsMarquee />
-            </div>
-
-            <div className="flex flex-col gap-6 min-w-0">
-              <div>
-                <h1 className="text-3xl sm:text-4xl font-bold tracking-tight leading-tight">
-                  The AI Agents Package Manager
-                </h1>
-                <p className="mt-4 text-neutral-400 text-base sm:text-lg leading-relaxed max-w-lg">
-                  Install AI agents, instructions, skills, and rules from GitHub repos into your
-                  project with a single command.
-                </p>
-              </div>
-
-              <CopyableCommand command="npx agentget add <owner/repo>" variant="hero" />
-            </div>
+      <section className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 pt-16 sm:pt-20 pb-20 sm:pb-28">
+        <div className="grid grid-cols-1 lg:grid-cols-[auto_1fr] gap-10 lg:gap-14 items-start">
+          <div className="w-[56ch] max-w-full">
+            <BrandMark />
+            <SupportedTargetsMarquee />
           </div>
-        </section>
 
-        <div className="border-t border-white/[0.06]">
-          <AgentsDirectory initialAgents={topAgents} />
-        </div>
+          <div className="flex flex-col gap-6 min-w-0">
+            <div>
+              <h1 className="text-3xl sm:text-4xl font-bold tracking-tight leading-tight">
+                The AI Agents Package Manager
+              </h1>
+              <p className="mt-4 text-neutral-400 text-base sm:text-lg leading-relaxed max-w-lg">
+                Install AI agents, instructions, skills, and rules from GitHub repos into your
+                project with a single command.
+              </p>
+            </div>
 
-        <div className="border-t border-white/[0.06]">
-          <SubmitAgentSection />
+            <CopyableCommand command="npx agentget add <owner/repo>" variant="hero" />
+          </div>
         </div>
+      </section>
 
-        <div className="border-t border-white/[0.06]">
-          <BuiltinAgents />
-        </div>
+      <div className="border-t border-white/[0.06]">
+        <AgentsDirectory initialAgents={topAgents} />
+      </div>
 
-        <div className="border-t border-white/[0.06]">
-          <DocsSection />
-        </div>
-      </main>
+      <div className="border-t border-white/[0.06]">
+        <SubmitAgentSection />
+      </div>
+
+      <div className="border-t border-white/[0.06]">
+        <BuiltinAgents />
+      </div>
+
+      <div className="border-t border-white/[0.06]">
+        <DocsSection />
+      </div>
     </>
   );
 }

--- a/website/components/AgentAudits.tsx
+++ b/website/components/AgentAudits.tsx
@@ -32,7 +32,7 @@ const CONTROL_STYLES = {
 
 export function AgentAudits() {
   return (
-    <main>
+    <div>
       <section className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 pt-16 sm:pt-20 pb-12 sm:pb-16">
         <div className="max-w-3xl">
           <span className="inline-flex items-center rounded-full border border-emerald-400/20 bg-emerald-400/10 px-3 py-1 text-xs font-medium uppercase tracking-[0.2em] text-emerald-300">
@@ -177,6 +177,6 @@ export function AgentAudits() {
           </div>
         </div>
       </section>
-    </main>
+    </div>
   );
 }

--- a/website/components/SiteFooter.tsx
+++ b/website/components/SiteFooter.tsx
@@ -1,0 +1,47 @@
+import Link from 'next/link';
+
+import { AGENT_SUBMISSION_URL } from '@/lib/github';
+
+export function SiteFooter() {
+  const year = new Date().getFullYear();
+
+  return (
+    <footer className="border-t border-white/[0.06]">
+      <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-8 flex flex-col sm:flex-row items-center justify-between gap-4 text-sm text-neutral-400">
+        <p>&copy; {year} agentget</p>
+        <nav aria-label="Footer" className="flex items-center gap-4 sm:gap-5 whitespace-nowrap">
+          <Link href="/docs" className="hover:text-white transition-colors">
+            Docs
+          </Link>
+          <Link href="/audits" className="hover:text-white transition-colors">
+            Audits
+          </Link>
+          <a
+            href={AGENT_SUBMISSION_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center rounded-full border border-emerald-400/30 bg-emerald-400/10 px-3 py-1 text-emerald-300 transition-colors hover:border-emerald-300/40 hover:bg-emerald-400/15 hover:text-emerald-200"
+          >
+            Submit Agent
+          </a>
+          <a
+            href="https://github.com/joeyism/agentget"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:text-white transition-colors"
+          >
+            GitHub
+          </a>
+          <a
+            href="https://www.npmjs.com/package/agentget"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:text-white transition-colors"
+          >
+            npm
+          </a>
+        </nav>
+      </div>
+    </footer>
+  );
+}

--- a/website/components/SiteHeader.tsx
+++ b/website/components/SiteHeader.tsx
@@ -1,18 +1,14 @@
+'use client';
+
 import Link from 'next/link';
+import { usePathname } from 'next/navigation';
 
 import { AGENT_SUBMISSION_URL } from '@/lib/github';
 
-type ActiveTab = 'home' | 'docs' | 'audits';
-
-export interface SiteHeaderProps {
-  active?: ActiveTab;
-  currentPath?: string;
-}
-
-export function SiteHeader({ active, currentPath }: SiteHeaderProps) {
-  const resolvedActive =
-    active ??
-    (currentPath?.startsWith('/docs') ? 'docs' : currentPath === '/audits' ? 'audits' : 'home');
+export function SiteHeader() {
+  const pathname = usePathname() ?? '/';
+  const activeTab =
+    pathname === '/audits' ? 'audits' : pathname.startsWith('/docs') ? 'docs' : 'home';
 
   const navLinkClass = (isActive: boolean) =>
     isActive ? 'text-white' : 'text-neutral-400 hover:text-white transition-colors';
@@ -38,14 +34,14 @@ export function SiteHeader({ active, currentPath }: SiteHeaderProps) {
           </Link>
         </div>
 
-        <nav className="flex items-center gap-4 sm:gap-5 text-sm whitespace-nowrap">
-          <Link href="/" className={navLinkClass(resolvedActive === 'home')}>
+        <nav aria-label="Primary" className="flex items-center gap-4 sm:gap-5 text-sm whitespace-nowrap">
+          <Link href="/" className={navLinkClass(activeTab === 'home')}>
             Home
           </Link>
-          <Link href="/docs" className={navLinkClass(resolvedActive === 'docs')}>
+          <Link href="/docs" className={navLinkClass(activeTab === 'docs')}>
             Docs
           </Link>
-          <Link href="/audits" className={navLinkClass(resolvedActive === 'audits')}>
+          <Link href="/audits" className={navLinkClass(activeTab === 'audits')}>
             Audits
           </Link>
           <a

--- a/website/css.d.ts
+++ b/website/css.d.ts
@@ -1,0 +1,1 @@
+declare module '*.css';


### PR DESCRIPTION
## Summary
- `SiteHeader` becomes a Client Component that derives the active tab from `usePathname()`, dropping the `active` / `currentPath` dual API. `<nav>` gets `aria-label="Primary"` so the landmark is named.
- [`website/app/layout.tsx`](website/app/layout.tsx) now owns the shell: a "Skip to content" link (first focusable), `<SiteHeader />`, `<main id="main" tabIndex={-1}>` wrapping `{children}`, and `<SiteFooter />`.
- Each page (`page.tsx`, `docs/`, `docs/agents/`, `docs/agents/[slug]/`, `agents/[...slug]/`, `audits/`) drops its `<SiteHeader>` and converts its `<main className="...">` wrapper to `<div className="...">` so there is exactly one `<main>` landmark per page (the one in layout). `AgentAudits.tsx` does the same `<main>` → `<div>` swap.
- New [`website/components/SiteFooter.tsx`](website/components/SiteFooter.tsx) (Server Component) mirrors the header's link set (Docs, Audits, Submit Agent, GitHub, npm) with `aria-label="Footer"` and a `© {year} agentget` line.
- No visual, logic, or metadata changes. Same Tailwind classes, same colors, same sticky header.

## Why this scope
The homepage audit flagged `SiteHeader` / `layout.tsx` as: per-page header, `active` vs `currentPath` dual API, no skip link, no footer. This PR fixes all four. Moving the header into layout means a new page just renders content — no header to remember. Consolidating `<main>` into layout gives one consistent landmark and lets us delete the per-page wrappers. The skip link + `tabIndex={-1}` on `<main>` makes the skip target focusable, not just scrollable.

## Test plan
- [ ] `npx tsc --noEmit` passes.
- [ ] Visual diff: homepage, `/docs`, `/docs/agents`, `/docs/agents/{slug}`, `/agents/{owner}/{repo}`, `/audits` look identical to PR 4 before/after.
- [ ] Header active tab is correct on every route (home → Home, `/docs/*` → Docs, `/audits` → Audits).
- [ ] Keyboard: Tab from the URL bar — first focus is "Skip to content"; Enter jumps focus into `<main>`.
- [ ] Screen reader (VoiceOver): one `<main>` landmark announced per page; nav announced as "Primary"; footer as "Footer".
- [ ] No duplicate `<main>` landmarks (confirm `AgentAudits` no longer renders `<main>`).
- [ ] Footer renders on every page with the correct year and links.
- [ ] Sticky header still sticks; z-index still above content.


Made with [Cursor](https://cursor.com)