### PR TITLE
Split DocsSection into a data file and a presentational component

### DIFF
--- a/website/components/DocsSection.tsx
+++ b/website/components/DocsSection.tsx
@@ -1,14 +1,56 @@
 import Link from "next/link";
 
+import supportedTargets from "@/public/supported-targets.json";
+import {
+  basicUsageLines,
+  canonicalReaders,
+  cliHintLines,
+  filteringFlags,
+  globalTargets,
+  installationLines,
+  projectTargets,
+  whatItInstalls,
+  type CodeLine,
+} from "@/lib/docs-section-data";
+
+const totalTools = (supportedTargets as Array<{ name: string }>).length;
+
+function CodeBlock({ lines }: { lines: CodeLine[] }) {
+  return (
+    <pre className="bg-neutral-900 border border-white/[0.06] text-neutral-100 rounded-lg p-4 overflow-x-auto font-mono text-sm leading-relaxed">
+      <code>
+        {lines.map((line, i) => (
+          <span key={i}>
+            {i > 0 && "\n"}
+            {line.type === "comment" ? (
+              <span className="text-neutral-500">{line.text}</span>
+            ) : (
+              line.text
+            )}
+          </span>
+        ))}
+      </code>
+    </pre>
+  );
+}
+
+function zebraRowClass(index: number) {
+  return `${index % 2 === 0 ? "bg-white/[0.02]" : ""} hover:bg-white/[0.04] transition-colors`;
+}
+
 export function DocsSection() {
   return (
     <section
       data-testid="docs-section"
+      aria-labelledby="docs-section-title"
       className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-16 sm:py-20"
     >
       {/* Section header */}
       <div className="mb-14">
-        <h2 className="text-2xl sm:text-3xl font-bold tracking-tight">
+        <h2
+          id="docs-section-title"
+          className="text-2xl sm:text-3xl font-bold tracking-tight"
+        >
           Quick Reference
         </h2>
         <p className="mt-2 text-neutral-400 text-sm sm:text-base">
@@ -22,21 +64,7 @@ export function DocsSection() {
           <h3 className="text-lg font-semibold mb-4 text-neutral-200">
             Installation
           </h3>
-          <pre className="bg-neutral-900 border border-white/[0.06] text-neutral-100 rounded-lg p-4 overflow-x-auto font-mono text-sm leading-relaxed">
-            <code>
-              <span className="text-neutral-500"># npm</span>
-              {"\n"}npm install -g agentget{"\n"}
-              {"\n"}
-              <span className="text-neutral-500"># bun</span>
-              {"\n"}bun add -g agentget{"\n"}
-              {"\n"}
-              <span className="text-neutral-500">
-                # Or use without installing:
-              </span>
-              {"\n"}npx agentget add owner/repo{"\n"}bunx agentget add
-              owner/repo
-            </code>
-          </pre>
+          <CodeBlock lines={installationLines} />
         </div>
 
         {/* ── Basic Usage ── */}
@@ -44,33 +72,7 @@ export function DocsSection() {
           <h3 className="text-lg font-semibold mb-4 text-neutral-200">
             Basic Usage
           </h3>
-          <pre className="bg-neutral-900 border border-white/[0.06] text-neutral-100 rounded-lg p-4 overflow-x-auto font-mono text-sm leading-relaxed">
-            <code>
-              <span className="text-neutral-500">
-                # Install all agents (default)
-              </span>
-              {"\n"}npx agentget add owner/repo{"\n"}
-              {"\n"}
-              <span className="text-neutral-500">
-                # Install everything (agents, skills, instructions, rules)
-              </span>
-              {"\n"}npx agentget add owner/repo --all{"\n"}
-              {"\n"}
-              <span className="text-neutral-500">
-                # Install a specific agent + all skills/instructions/rules
-              </span>
-              {"\n"}npx agentget add owner/repo --agent code-reviewer{"\n"}
-              {"\n"}
-              <span className="text-neutral-500"># Install only skills</span>
-              {"\n"}npx agentget add owner/repo --skills-only{"\n"}
-              {"\n"}
-              <span className="text-neutral-500">
-                # Install specific agent only (no extras)
-              </span>
-              {"\n"}npx agentget add owner/repo --agent code-reviewer
-              --agents-only
-            </code>
-          </pre>
+          <CodeBlock lines={basicUsageLines} />
         </div>
 
         {/* ── Filtering Flags ── */}
@@ -80,35 +82,22 @@ export function DocsSection() {
           </h3>
           <div className="overflow-x-auto rounded-lg border border-white/[0.06]">
             <table className="w-full text-sm">
+              <caption className="sr-only">
+                Filtering flags and their install behavior
+              </caption>
               <thead>
                 <tr className="bg-neutral-900 text-left">
-                  <th className="px-4 py-3 font-medium text-neutral-400 whitespace-nowrap">
+                  <th scope="col" className="px-4 py-3 font-medium text-neutral-400 whitespace-nowrap">
                     Flag
                   </th>
-                  <th className="px-4 py-3 font-medium text-neutral-400">
+                  <th scope="col" className="px-4 py-3 font-medium text-neutral-400">
                     Behavior
                   </th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-white/[0.06]">
-                {[
-                  ["(none)", "Installs agents only (default)"],
-                  ["--all", "Installs everything"],
-                  [
-                    "--agent <name>",
-                    "Installs specified agent + all skills/instructions/rules",
-                  ],
-                  ["--agents-only", "Installs agents only (explicit)"],
-                  ["--skills-only", "Installs skills only"],
-                  ["--instructions-only", "Installs instructions only"],
-                  ["--rules-only", "Installs rules only"],
-                ].map(([flag, behavior], i) => (
-                  <tr
-                    key={flag}
-                    className={
-                      `${i % 2 === 0 ? "bg-white/[0.02]" : ""} hover:bg-white/[0.04] transition-colors`
-                    }
-                  >
+                {filteringFlags.map(({ flag, behavior }, i) => (
+                  <tr key={flag} className={zebraRowClass(i)}>
                     <td className="px-4 py-2.5 font-mono text-emerald-400 whitespace-nowrap">
                       {flag}
                     </td>
@@ -127,7 +116,7 @@ export function DocsSection() {
           </h3>
 
           <p className="text-sm text-neutral-400 mb-4 leading-relaxed">
-            agentget supports <span className="text-white font-medium">41 AI coding tools</span>.
+            agentget supports <span className="text-white font-medium">{totalTools} AI coding tools</span>.
             Content is written to a canonical location, then symlinked to detected tool directories.
           </p>
 
@@ -135,7 +124,7 @@ export function DocsSection() {
           <div className="bg-neutral-900/50 border border-white/[0.06] rounded-lg p-4 mb-6 space-y-2">
             <p className="text-sm text-neutral-300">
               <span className="text-emerald-400 font-medium">Supported</span>{" "}
-              — all 41 tools agentget knows how to install into
+              — all {totalTools} tools agentget knows how to install into
             </p>
             <p className="text-sm text-neutral-300">
               <span className="text-emerald-400 font-medium">Detected</span>{" "}
@@ -143,7 +132,7 @@ export function DocsSection() {
             </p>
             <p className="text-sm text-neutral-300">
               <span className="text-emerald-400 font-medium">Canonical</span>{" "}
-              — 10 tools that read <code className="text-neutral-400 bg-neutral-800 px-1 rounded">.agents/</code> directly. Always active, no symlink needed.
+              — {canonicalReaders.length} tools that read <code className="text-neutral-400 bg-neutral-800 px-1 rounded">.agents/</code> directly. Always active, no symlink needed.
             </p>
           </div>
 
@@ -164,10 +153,7 @@ export function DocsSection() {
             Canonical readers (always active — read <code className="text-neutral-400 bg-neutral-800 px-1 rounded">.agents/</code> directly):
           </p>
           <div className="flex flex-wrap gap-2 mb-6">
-            {[
-              "AMP", "Cline", "Codex", "Cursor", "Gemini CLI",
-              "GitHub Copilot", "Kimi Code CLI", "OpenCode", "Replit", "Universal",
-            ].map((name) => (
+            {canonicalReaders.map((name) => (
               <span
                 key={name}
                 className="inline-block px-2.5 py-1 text-xs font-mono text-neutral-300 bg-neutral-800/60 border border-white/[0.06] rounded-md"
@@ -181,60 +167,26 @@ export function DocsSection() {
           <details className="group mb-4">
             <summary className="text-sm text-neutral-500 cursor-pointer hover:text-neutral-300 transition-colors mb-3 list-none flex items-center gap-2">
               <span className="text-neutral-600 group-open:rotate-90 transition-transform inline-block">&#9654;</span>
-              Project targets (31 tools) — symlinked when detected
+              Project targets ({projectTargets.length} tools) — symlinked when detected
             </summary>
             <div className="overflow-x-auto rounded-lg border border-white/[0.06] mt-2">
               <table className="w-full text-sm">
+                <caption className="sr-only">
+                  Project target tools and their symlink paths
+                </caption>
                 <thead>
                   <tr className="bg-neutral-900 text-left">
-                    <th className="px-4 py-3 font-medium text-neutral-400">
+                    <th scope="col" className="px-4 py-3 font-medium text-neutral-400">
                       Tool
                     </th>
-                    <th className="px-4 py-3 font-medium text-neutral-400">
+                    <th scope="col" className="px-4 py-3 font-medium text-neutral-400">
                       Path
                     </th>
                   </tr>
                 </thead>
                 <tbody className="divide-y divide-white/[0.06]">
-                  {([
-                    ["AdaL", ".adal/"],
-                    ["Antigravity", ".agent/"],
-                    ["Augment", ".augment/"],
-                    ["Claude Code", ".claude/"],
-                    ["CodeBuddy", ".codebuddy/"],
-                    ["Command Code", ".commandcode/"],
-                    ["Continue", ".continue/"],
-                    ["Cortex Code", ".cortex/"],
-                    ["Crush", ".crush/"],
-                    ["Droid", ".factory/"],
-                    ["Goose", ".goose/"],
-                    ["iFlow CLI", ".iflow/"],
-                    ["Junie", ".junie/"],
-                    ["Kilo Code", ".kilocode/"],
-                    ["Kiro CLI", ".kiro/"],
-                    ["Kode", ".kode/"],
-                    ["MCPJam", ".mcpjam/"],
-                    ["Mistral Vibe", ".vibe/"],
-                    ["Mux", ".mux/"],
-                    ["Neovate", ".neovate/"],
-                    ["OpenClaw", "* (marker-gated)"],
-                    ["OpenHands", ".openhands/"],
-                    ["Pi", ".pi/"],
-                    ["Pochi", ".pochi/"],
-                    ["Qoder", ".qoder/"],
-                    ["Qwen Code", ".qwen/"],
-                    ["Roo Code", ".roo/"],
-                    ["Trae", ".trae/"],
-                    ["Trae CN", ".trae/"],
-                    ["Windsurf", ".windsurf/"],
-                    ["Zencoder", ".zencoder/"],
-                  ] as const).map(([tool, path], i) => (
-                    <tr
-                      key={tool}
-                      className={
-                        `${i % 2 === 0 ? "bg-white/[0.02]" : ""} hover:bg-white/[0.04] transition-colors`
-                      }
-                    >
+                  {projectTargets.map(({ tool, path }, i) => (
+                    <tr key={tool} className={zebraRowClass(i)}>
                       <td className="px-4 py-2 text-neutral-300 whitespace-nowrap">
                         {tool}
                       </td>
@@ -252,70 +204,29 @@ export function DocsSection() {
           <details className="group mb-6">
             <summary className="text-sm text-neutral-500 cursor-pointer hover:text-neutral-300 transition-colors mb-3 list-none flex items-center gap-2">
               <span className="text-neutral-600 group-open:rotate-90 transition-transform inline-block">&#9654;</span>
-              Global targets (41 tools) — symlinked when config directory exists
+              Global targets ({totalTools} tools) — symlinked when config directory exists
             </summary>
             <p className="text-xs text-neutral-600 mb-2 mt-2">
               Only created when the tool&apos;s home directory exists or an env var points to it.
             </p>
             <div className="overflow-x-auto rounded-lg border border-white/[0.06] mt-2">
               <table className="w-full text-sm">
+                <caption className="sr-only">
+                  Global target tools and their config paths
+                </caption>
                 <thead>
                   <tr className="bg-neutral-900 text-left">
-                    <th className="px-4 py-3 font-medium text-neutral-400">
+                    <th scope="col" className="px-4 py-3 font-medium text-neutral-400">
                       Tool
                     </th>
-                    <th className="px-4 py-3 font-medium text-neutral-400">
+                    <th scope="col" className="px-4 py-3 font-medium text-neutral-400">
                       Global path
                     </th>
                   </tr>
                 </thead>
                 <tbody className="divide-y divide-white/[0.06]">
-                  {([
-                    ["AdaL", "~/.adal/"],
-                    ["AMP / Kimi Code CLI / Replit / Universal", "~/.config/agents/"],
-                    ["Antigravity", "~/.gemini/antigravity/"],
-                    ["Augment", "~/.augment/"],
-                    ["Claude Code", "${CLAUDE_CONFIG_DIR:-~/.claude}/"],
-                    ["Cline", "~/.agents/"],
-                    ["CodeBuddy", "~/.codebuddy/"],
-                    ["Codex", "${CODEX_HOME:-~/.codex}/"],
-                    ["Command Code", "~/.commandcode/"],
-                    ["Continue", "~/.continue/"],
-                    ["Cortex Code", "~/.snowflake/cortex/"],
-                    ["Crush", "~/.config/crush/"],
-                    ["Cursor", "~/.cursor/"],
-                    ["Droid", "~/.factory/"],
-                    ["Gemini CLI", "~/.gemini/"],
-                    ["GitHub Copilot", "~/.copilot/"],
-                    ["Goose", "~/.config/goose/"],
-                    ["iFlow CLI", "~/.iflow/"],
-                    ["Junie", "~/.junie/"],
-                    ["Kilo Code", "~/.kilocode/"],
-                    ["Kiro CLI", "~/.kiro/"],
-                    ["Kode", "~/.kode/"],
-                    ["MCPJam", "~/.mcpjam/"],
-                    ["Mistral Vibe", "~/.vibe/"],
-                    ["Mux", "~/.mux/"],
-                    ["Neovate", "~/.neovate/"],
-                    ["OpenClaw", "~/.openclaw/"],
-                    ["OpenCode", "~/.config/opencode/"],
-                    ["OpenHands", "~/.openhands/"],
-                    ["Pi", "~/.pi/agent/"],
-                    ["Pochi", "~/.pochi/"],
-                    ["Qoder", "~/.qoder/"],
-                    ["Qwen Code", "~/.qwen/"],
-                    ["Roo Code", "~/.roo/"],
-                    ["Trae", "~/.trae/"],
-                    ["Trae CN", "~/.trae-cn/"],
-                    ["Windsurf", "~/.codeium/windsurf/"],
-                    ["Zencoder", "~/.zencoder/"],
-                  ] as const).map(([tool, path], i) => (
-                    <tr
-                      key={tool}
-                      className={
-                        `${i % 2 === 0 ? "bg-white/[0.02]" : ""} hover:bg-white/[0.04] transition-colors`
-                      }
-                    >
+                  {globalTargets.map(({ tool, path }, i) => (
+                    <tr key={tool} className={zebraRowClass(i)}>
                       <td className="px-4 py-2 text-neutral-300 whitespace-nowrap">
                         {tool}
                       </td>
@@ -330,12 +241,7 @@ export function DocsSection() {
           </details>
 
           {/* CLI hint */}
-          <pre className="bg-neutral-900 border border-white/[0.06] text-neutral-100 rounded-lg p-4 overflow-x-auto font-mono text-sm leading-relaxed">
-            <code>
-              <span className="text-neutral-500"># See all supported targets and which are detected on your machine</span>
-              {"\n"}npx agentget targets
-            </code>
-          </pre>
+          <CodeBlock lines={cliHintLines} />
         </div>
 
         {/* ── What It Installs ── */}
@@ -345,30 +251,22 @@ export function DocsSection() {
           </h3>
           <div className="overflow-x-auto rounded-lg border border-white/[0.06]">
             <table className="w-full text-sm">
+              <caption className="sr-only">
+                Content types and the file patterns agentget installs
+              </caption>
               <thead>
                 <tr className="bg-neutral-900 text-left">
-                  <th className="px-4 py-3 font-medium text-neutral-400">
+                  <th scope="col" className="px-4 py-3 font-medium text-neutral-400">
                     Type
                   </th>
-                  <th className="px-4 py-3 font-medium text-neutral-400">
+                  <th scope="col" className="px-4 py-3 font-medium text-neutral-400">
                     Pattern
                   </th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-white/[0.06]">
-                {[
-                  ["Agents", "agents/*.agent.md"],
-                  ["Instructions", "instructions/*.instructions.md"],
-                  ["Skills", "skills/*/SKILL.md (whole folder)"],
-                  ["Rules", "rules/*.rules.md"],
-                  ["Plugins", "plugins/*/ (expanded recursively)"],
-                ].map(([type, pattern], i) => (
-                  <tr
-                    key={type}
-                    className={
-                      `${i % 2 === 0 ? "bg-white/[0.02]" : ""} hover:bg-white/[0.04] transition-colors`
-                    }
-                  >
+                {whatItInstalls.map(({ type, pattern }, i) => (
+                  <tr key={type} className={zebraRowClass(i)}>
                     <td className="px-4 py-2.5 text-neutral-300 font-medium whitespace-nowrap">
                       {type}
                     </td>

--- a/website/lib/docs-section-data.ts
+++ b/website/lib/docs-section-data.ts
@@ -1,0 +1,139 @@
+// Keep in sync with src/agents.ts. A future PR will emit the canonical/project/global
+// breakdown from website/scripts/build-data.ts once AgentTarget exposes a displayPath.
+// The total tool count (41) already comes from public/supported-targets.json.
+
+export type CodeLine = { type: 'comment'; text: string } | { type: 'command'; text: string };
+
+export const installationLines: CodeLine[] = [
+  { type: 'comment', text: '# npm' },
+  { type: 'command', text: 'npm install -g agentget' },
+  { type: 'comment', text: '# bun' },
+  { type: 'command', text: 'bun add -g agentget' },
+  { type: 'comment', text: '# Or use without installing:' },
+  { type: 'command', text: 'npx agentget add owner/repo' },
+  { type: 'command', text: 'bunx agentget add owner/repo' },
+];
+
+export const basicUsageLines: CodeLine[] = [
+  { type: 'comment', text: '# Install all agents (default)' },
+  { type: 'command', text: 'npx agentget add owner/repo' },
+  { type: 'comment', text: '# Install everything (agents, skills, instructions, rules)' },
+  { type: 'command', text: 'npx agentget add owner/repo --all' },
+  { type: 'comment', text: '# Install a specific agent + all skills/instructions/rules' },
+  { type: 'command', text: 'npx agentget add owner/repo --agent code-reviewer' },
+  { type: 'comment', text: '# Install only skills' },
+  { type: 'command', text: 'npx agentget add owner/repo --skills-only' },
+  { type: 'comment', text: '# Install specific agent only (no extras)' },
+  { type: 'command', text: 'npx agentget add owner/repo --agent code-reviewer --agents-only' },
+];
+
+export const cliHintLines: CodeLine[] = [
+  { type: 'comment', text: '# See all supported targets and which are detected on your machine' },
+  { type: 'command', text: 'npx agentget targets' },
+];
+
+export const filteringFlags: { flag: string; behavior: string }[] = [
+  { flag: '(none)', behavior: 'Installs agents only (default)' },
+  { flag: '--all', behavior: 'Installs everything' },
+  { flag: '--agent <name>', behavior: 'Installs specified agent + all skills/instructions/rules' },
+  { flag: '--agents-only', behavior: 'Installs agents only (explicit)' },
+  { flag: '--skills-only', behavior: 'Installs skills only' },
+  { flag: '--instructions-only', behavior: 'Installs instructions only' },
+  { flag: '--rules-only', behavior: 'Installs rules only' },
+];
+
+export const whatItInstalls: { type: string; pattern: string }[] = [
+  { type: 'Agents', pattern: 'agents/*.agent.md' },
+  { type: 'Instructions', pattern: 'instructions/*.instructions.md' },
+  { type: 'Skills', pattern: 'skills/*/SKILL.md (whole folder)' },
+  { type: 'Rules', pattern: 'rules/*.rules.md' },
+  { type: 'Plugins', pattern: 'plugins/*/ (expanded recursively)' },
+];
+
+export const canonicalReaders: string[] = [
+  'AMP',
+  'Cline',
+  'Codex',
+  'Cursor',
+  'Gemini CLI',
+  'GitHub Copilot',
+  'Kimi Code CLI',
+  'OpenCode',
+  'Replit',
+  'Universal',
+];
+
+export const projectTargets: { tool: string; path: string }[] = [
+  { tool: 'AdaL', path: '.adal/' },
+  { tool: 'Antigravity', path: '.agent/' },
+  { tool: 'Augment', path: '.augment/' },
+  { tool: 'Claude Code', path: '.claude/' },
+  { tool: 'CodeBuddy', path: '.codebuddy/' },
+  { tool: 'Command Code', path: '.commandcode/' },
+  { tool: 'Continue', path: '.continue/' },
+  { tool: 'Cortex Code', path: '.cortex/' },
+  { tool: 'Crush', path: '.crush/' },
+  { tool: 'Droid', path: '.factory/' },
+  { tool: 'Goose', path: '.goose/' },
+  { tool: 'iFlow CLI', path: '.iflow/' },
+  { tool: 'Junie', path: '.junie/' },
+  { tool: 'Kilo Code', path: '.kilocode/' },
+  { tool: 'Kiro CLI', path: '.kiro/' },
+  { tool: 'Kode', path: '.kode/' },
+  { tool: 'MCPJam', path: '.mcpjam/' },
+  { tool: 'Mistral Vibe', path: '.vibe/' },
+  { tool: 'Mux', path: '.mux/' },
+  { tool: 'Neovate', path: '.neovate/' },
+  { tool: 'OpenClaw', path: '* (marker-gated)' },
+  { tool: 'OpenHands', path: '.openhands/' },
+  { tool: 'Pi', path: '.pi/' },
+  { tool: 'Pochi', path: '.pochi/' },
+  { tool: 'Qoder', path: '.qoder/' },
+  { tool: 'Qwen Code', path: '.qwen/' },
+  { tool: 'Roo Code', path: '.roo/' },
+  { tool: 'Trae', path: '.trae/' },
+  { tool: 'Trae CN', path: '.trae/' },
+  { tool: 'Windsurf', path: '.windsurf/' },
+  { tool: 'Zencoder', path: '.zencoder/' },
+];
+
+export const globalTargets: { tool: string; path: string }[] = [
+  { tool: 'AdaL', path: '~/.adal/' },
+  { tool: 'AMP / Kimi Code CLI / Replit / Universal', path: '~/.config/agents/' },
+  { tool: 'Antigravity', path: '~/.gemini/antigravity/' },
+  { tool: 'Augment', path: '~/.augment/' },
+  { tool: 'Claude Code', path: '${CLAUDE_CONFIG_DIR:-~/.claude}/' },
+  { tool: 'Cline', path: '~/.agents/' },
+  { tool: 'CodeBuddy', path: '~/.codebuddy/' },
+  { tool: 'Codex', path: '${CODEX_HOME:-~/.codex}/' },
+  { tool: 'Command Code', path: '~/.commandcode/' },
+  { tool: 'Continue', path: '~/.continue/' },
+  { tool: 'Cortex Code', path: '~/.snowflake/cortex/' },
+  { tool: 'Crush', path: '~/.config/crush/' },
+  { tool: 'Cursor', path: '~/.cursor/' },
+  { tool: 'Droid', path: '~/.factory/' },
+  { tool: 'Gemini CLI', path: '~/.gemini/' },
+  { tool: 'GitHub Copilot', path: '~/.copilot/' },
+  { tool: 'Goose', path: '~/.config/goose/' },
+  { tool: 'iFlow CLI', path: '~/.iflow/' },
+  { tool: 'Junie', path: '~/.junie/' },
+  { tool: 'Kilo Code', path: '~/.kilocode/' },
+  { tool: 'Kiro CLI', path: '~/.kiro/' },
+  { tool: 'Kode', path: '~/.kode/' },
+  { tool: 'MCPJam', path: '~/.mcpjam/' },
+  { tool: 'Mistral Vibe', path: '~/.vibe/' },
+  { tool: 'Mux', path: '~/.mux/' },
+  { tool: 'Neovate', path: '~/.neovate/' },
+  { tool: 'OpenClaw', path: '~/.openclaw/' },
+  { tool: 'OpenCode', path: '~/.config/opencode/' },
+  { tool: 'OpenHands', path: '~/.openhands/' },
+  { tool: 'Pi', path: '~/.pi/agent/' },
+  { tool: 'Pochi', path: '~/.pochi/' },
+  { tool: 'Qoder', path: '~/.qoder/' },
+  { tool: 'Qwen Code', path: '~/.qwen/' },
+  { tool: 'Roo Code', path: '~/.roo/' },
+  { tool: 'Trae', path: '~/.trae/' },
+  { tool: 'Trae CN', path: '~/.trae-cn/' },
+  { tool: 'Windsurf', path: '~/.codeium/windsurf/' },
+  { tool: 'Zencoder', path: '~/.zencoder/' },
+];


### PR DESCRIPTION
## Summary
- New [`website/lib/docs-section-data.ts`](website/lib/docs-section-data.ts) holds the four inline arrays (filtering flags, what-it-installs, canonical readers, project/global targets) and three code-block line arrays (installation, basic usage, CLI hint) as typed data. A `CodeLine` union (`'comment' | 'command'`) replaces the `{"\n"}` string-concatenation pattern. Header comment notes the sync responsibility with `src/agents.ts`.
- [`website/components/DocsSection.tsx`](website/components/DocsSection.tsx) becomes a presentational component: it imports the data, maps over the arrays to render table rows, and uses a local `CodeBlock` helper for the shell examples. ~400 lines of mixed markup/data → ~290 lines of markup + ~150 lines of typed data.
- A11y fixes (same class as PR 4 in `AgentsDirectory`): `scope="col"` on every `<th>`, `<caption className="sr-only">` on every `<table>`, `aria-labelledby="docs-section-title"` on the `<section>` with a matching `id` on the `<h2>`.
- Counts come from data, not literals: the "41 AI coding tools" total and "Global targets (41 tools)" use `supportedTargets.length` from `public/supported-targets.json` (already emitted by `build-data.ts` from `AGENTS`, so adding a tool updates the total automatically). "Canonical readers (10)" uses `canonicalReaders.length`; "Project targets (31 tools)" uses `projectTargets.length`.
- No visual, copy, color, spacing, or `<details>`/`<summary>` behavior changes.

## Why this scope
The audit called `DocsSection` "~400 lines of hardcoded CLI docs that will rot." This PR makes the component presentational and puts the rot-prone strings in one typed file with a sync note. The total tool count already comes from the source of truth (`supported-targets.json`); the 10/31/38 breakdown stays hand-maintained because emitting it from `build-data.ts` requires adding a `displayPath` field to `AgentTarget` in `src/agents.ts` (~50 entries) — a cross-cutting CLI-core change that's easier to review as its own PR.

## Test plan
- [ ] `npx tsc --noEmit` passes.
- [ ] Visual diff: homepage docs section looks identical to PR 5 before/after at sm/md/lg.
- [ ] Every table has `scope="col"` on `<th>` and a sr-only `<caption>`.
- [ ] Section has `aria-labelledby="docs-section-title"`; `<h2>` has matching `id`.
- [ ] Counts render correctly: 41 (total), 10 (canonical), 31 (project rows), 41 (global summary).
- [ ] `<details>` collapsibles still open/close; triangle still rotates.
- [ ] Code blocks render with correct newlines and comment styling (npm/bun/npx/bunx block, basic-usage block, `npx agentget targets` hint).
- [ ] "View builtin agent docs" link still works.


Made with [Cursor](https://cursor.com)