### PR TITLE
Respect prefers-reduced-motion and fix marquee a11y

### DIFF
--- a/website/app/globals.css
+++ b/website/app/globals.css
@@ -45,3 +45,9 @@ body {
 .marquee-track:hover {
   animation-play-state: paused;
 }
+
+@media (prefers-reduced-motion: reduce) {
+  .marquee-track {
+    animation: none;
+  }
+}

--- a/website/components/SupportedTargetsMarquee.tsx
+++ b/website/components/SupportedTargetsMarquee.tsx
@@ -1,13 +1,8 @@
 import Image from "next/image";
 import supportedTargets from "@/public/supported-targets.json";
+import { TARGET_ICONS } from "@/lib/target-icons";
 
 const marqueeTargets = supportedTargets as Array<{ name: string }>;
-
-const TARGET_ICONS: Record<string, string> = {
-  "Claude Code": "/agents/claude-code.svg",
-  Cursor: "/agents/cursor.svg",
-  OpenCode: "/agents/opencode.svg",
-};
 
 function getTargetFallback(name: string): string {
   const words = name.replace(/[^A-Za-z0-9 ]/g, "").split(/\s+/).filter(Boolean);
@@ -28,11 +23,14 @@ function TargetBadge({ name }: { name: string }) {
 
   return (
     <div className="flex items-center gap-3 rounded-xl border border-white/[0.08] bg-white/[0.02] px-3 py-2 text-neutral-300 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]">
-      <div className="flex h-9 w-9 shrink-0 items-center justify-center overflow-hidden rounded-lg border border-white/[0.08] bg-neutral-900 text-[10px] font-semibold tracking-[0.14em] text-neutral-400 uppercase">
+      <div
+        aria-hidden="true"
+        className="flex h-9 w-9 shrink-0 items-center justify-center overflow-hidden rounded-lg border border-white/[0.08] bg-neutral-900 text-[10px] font-semibold tracking-[0.14em] text-neutral-400 uppercase"
+      >
         {iconSrc ? (
           <Image
             src={iconSrc}
-            alt={name}
+            alt=""
             width={36}
             height={36}
             className="h-full w-full rounded-lg object-cover"
@@ -51,8 +49,15 @@ function TargetBadge({ name }: { name: string }) {
 
 export function SupportedTargetsMarquee() {
   return (
-    <section data-testid="marquee-section" className="w-full max-w-full pt-16 sm:pt-24">
-      <h2 className="text-left text-sm font-medium uppercase tracking-widest text-neutral-500 mb-6 pl-1">
+    <section
+      data-testid="marquee-section"
+      aria-labelledby="marquee-title"
+      className="w-full max-w-full pt-16 sm:pt-24"
+    >
+      <h2
+        id="marquee-title"
+        className="text-left text-sm font-medium uppercase tracking-widest text-neutral-500 mb-6 pl-1"
+      >
         Compatible with these coding tools
       </h2>
       <div className="relative overflow-hidden rounded-2xl">
@@ -60,7 +65,11 @@ export function SupportedTargetsMarquee() {
         <div className="pointer-events-none absolute inset-y-0 right-0 z-10 w-14 bg-gradient-to-l from-black to-transparent" />
         <div className="marquee-track flex w-max items-center gap-4 px-10 sm:gap-6 sm:px-12">
           {[0, 1].map((set) => (
-            <div key={set} className="flex shrink-0 items-center gap-4 pr-4 sm:gap-6 sm:pr-6">
+            <div
+              key={set}
+              aria-hidden={set === 1 ? true : undefined}
+              className="flex shrink-0 items-center gap-4 pr-4 sm:gap-6 sm:pr-6"
+            >
               {marqueeTargets.map((target) => (
                 <TargetBadge key={`${set}-${target.name}`} name={target.name} />
               ))}

--- a/website/lib/target-icons.ts
+++ b/website/lib/target-icons.ts
@@ -1,0 +1,9 @@
+// Keep in sync with SVGs in website/public/agents/.
+// A future PR will emit an icon field from website/scripts/build-data.ts
+// once AgentTarget exposes one.
+
+export const TARGET_ICONS: Record<string, string> = {
+  "Claude Code": "/agents/claude-code.svg",
+  Cursor: "/agents/cursor.svg",
+  OpenCode: "/agents/opencode.svg",
+};


### PR DESCRIPTION
## Summary
- [`website/app/globals.css`](website/app/globals.css): add `@media (prefers-reduced-motion: reduce) { .marquee-track { animation: none; } }` so the infinite scroll stops for users who prefer reduced motion. The track shows the first set statically; the existing `:hover` pause becomes a no-op.
- New [`website/lib/target-icons.ts`](website/lib/target-icons.ts): moves the 3-entry `TARGET_ICONS` map out of the component into a typed data file with a sync note. Same posture as PR 6's `docs-section-data.ts` — the full `build-data.ts` integration (emit an `icon` field per target) is deferred since it requires adding `icon` to `AgentTarget` in `src/agents.ts`.
- [`website/components/SupportedTargetsMarquee.tsx`](website/components/SupportedTargetsMarquee.tsx): imports `TARGET_ICONS` from the data file and fixes three a11y holes:
  - `aria-labelledby="marquee-title"` on the `<section>` + `id="marquee-title"` on the `<h2>`.
  - `aria-hidden="true"` on the second set in the `[0, 1].map` (the duplicate that exists only for the seamless `translateX(-50%)` loop) so screen readers announce 41 names once, not 82.
  - `aria-hidden="true"` on the decorative icon container + `alt=""` on the icon `Image` (the name is already in the adjacent `<span>`, so the icon is decorative — today AT hears the name twice per badge).
- No visual changes. The marquee stays a Server Component.

## Why this scope
The audit flagged `SupportedTargetsMarquee.tsx` for `prefers-reduced-motion` and the hardcoded icon map. The reduced-motion fix is CSS-only (no JS, no client boundary, no layout shift). The icon map move is the same partial step PR 6 took — data out of the component, defer the cross-cutting `build-data.ts` integration. The three a11y fixes were found during the read-through: the duplicate-set announcement and the double name per badge are real AT bugs that fall out of the `[0, 1]` duplication trick and the `alt={name}` + sibling span pattern.

## Test plan
- [ ] `npx tsc --noEmit` passes.
- [ ] Visual diff: homepage marquee looks identical to PR 6 before/after at sm/md/lg.
- [ ] macOS: toggle "Reduce motion" in System Settings > Accessibility > Display; reload homepage — marquee holds still, no scroll.
- [ ] With motion on: marquee still scrolls, hover still pauses.
- [ ] Screen reader (VoiceOver): section announced as "Compatible with these coding tools" via `aria-labelledby`; 41 names announced once (not 82); icon images silent (decorative).


Made with [Cursor](https://cursor.com)